### PR TITLE
ci: restore auto-tag, version, and release on merge to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,22 +1,51 @@
 name: Release
 
 on:
-  release:
-    types: [published]
+  push:
+    branches:
+      - main
 
 permissions:
   contents: write
+  actions: write
   pages: write
   deployments: write
 
 jobs:
-  deploy:
-    name: Deploy GitHub Pages
+  record-release:
+    if: "!contains(github.event.commits[0].message, '[ci skip]')"
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
+
+      - name: Compute version
+        id: version
+        run: |
+          git log --no-walk --tags --oneline --since $(date +%Y/01/01)
+          export YEAR=$(date '+%y')
+          export TAG_COUNT=$(git log --no-walk --tags --oneline --since $(date +%Y/01/01) | wc -l | tr -dc '0-9')
+          export VERSION=$YEAR.$TAG_COUNT.0
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Tag and release
+        run: |
+          git config --global user.email "ci@uvasoftware.com"
+          git config --global user.name "Github Actions"
+          git tag -a v"${VERSION}" -m "Release by Github Actions v${VERSION}"
+          git push origin v"${VERSION}"
+          gh release create --generate-notes v"${VERSION}"
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          GITHUB_TOKEN: ${{ github.token }}
+
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
 
       - name: Generate Swagger UI (v2.2)
         uses: Legion2/swagger-ui-action@v1

--- a/Readme.md
+++ b/Readme.md
@@ -1,9 +1,20 @@
-[Scanii](https://www.scanii.com) Content Identification API Specification
+# Scanii API Specification
 
-API specifications use [openapi](https://www.openapis.org). 
+The OpenAPI 3.1 specification for the [Scanii](https://www.scanii.com) Content Identification API.
 
-Latest version (v2.2)
-* https://scanii.github.io/openapi/v22
+## Browse the spec
 
-Previous versions
-* https://scanii.github.io/openapi/v21 - v2.1
+- **Latest — v2.2:** https://scanii.github.io/openapi/v22
+- v2.1: https://scanii.github.io/openapi/v21
+
+The raw YAML lives in [`src/`](src/).
+
+## Get an API key
+
+Sign up at [www.scanii.com](https://www.scanii.com) — free tier, 60 seconds.
+
+## Contributing
+
+Spec corrections and clarifications welcome — open a PR against the relevant `src/v*.yaml`. Questions: support@uvasoftware.com.
+
+Apache 2.0 — see [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary

Restores the original push-to-main trigger with automatic versioning, tagging, and GitHub Release creation that was removed in PR #42.

- **Trigger**: `push: branches: [main]` (fires on every merge to main)
- **`record-release` job**: computes a `YY.N.0` version from the year-to-date tag count, creates an annotated git tag, pushes it, and opens a GitHub Release with auto-generated notes
- **`generate` job**: builds Swagger UI for v2.2 and v2.1, deploys to GitHub Pages — runs in parallel with `record-release`, unchanged from the original

## Test plan

- [ ] Merge to main triggers both jobs
- [ ] Tag and release are created automatically
- [ ] GitHub Pages is updated with latest spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)