### PR TITLE
Render OpenAPI 3.1 specs by upgrading Swagger UI to 5.x

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,17 +48,19 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Generate Swagger UI (v2.2)
-        uses: Legion2/swagger-ui-action@v1
+        uses: Legion2/swagger-ui-action@v1.3.0
         with:
           output: dist/v22
           spec-file: src/v22.yaml
+          version: ^5.0.0
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate Swagger UI (v2.1)
-        uses: Legion2/swagger-ui-action@v1
+        uses: Legion2/swagger-ui-action@v1.3.0
         with:
           output: dist/v21
           spec-file: src/v21.yaml
+          version: ^5.0.0
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
## Summary
- The deployed docs site was failing to render `v22.yaml` with *\"The provided definition does not specify a valid version field\"* after the spec was bumped to `openapi: 3.1.0` in c379d0f.
- Root cause: `Legion2/swagger-ui-action@v1` defaults to bundling Swagger UI `^3.0.0`, which predates OpenAPI 3.1 support.
- Pinned the action to `@v1.3.0` and passed `version: ^5.0.0` so the deployed assets are Swagger UI 5.x — handles 3.1 (and renders 3.0.x identically).
- Applied the same `version: ^5.0.0` to the v2.1 render step for consistency, even though 3.0.3 worked under the old default.

## Test plan
- [ ] Merge to main, watch the `Release` workflow deploy to GitHub Pages
- [ ] Open `https://scanii.github.io/openapi/v22/` and confirm the spec renders (no version-field error)
- [ ] Open `https://scanii.github.io/openapi/v21/` and confirm v2.1 still renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)